### PR TITLE
feat: migrate from Decap CMS to Sveltia CMS

### DIFF
--- a/CMS_SETUP.md
+++ b/CMS_SETUP.md
@@ -1,8 +1,8 @@
-# Decap CMS Setup Guide
+# Sveltia CMS Setup Guide
 
 ## Overview
 
-This site now has Decap CMS configured with GitHub authentication via Vercel and Cloudinary for media management.
+This site uses Sveltia CMS with GitHub authentication via Vercel for content management. Sveltia CMS is a modern, drop-in replacement for Decap/Netlify CMS with improved performance and built-in asset management.
 
 ## Setup Steps
 
@@ -26,14 +26,6 @@ In your Vercel project settings → Environment Variables, add:
 #### In `/admin/config.yml`:
 
 - Replace `YOUR_PRODUCTION_DOMAIN` with your actual domain (e.g., joehart.co.uk)
-- Replace `YOUR_CLOUDINARY_CLOUD_NAME` with your Cloudinary cloud name
-- Replace `YOUR_CLOUDINARY_API_KEY` with your Cloudinary API key
-
-### 4. Cloudinary Setup
-
-1. Log into your Cloudinary account
-2. Find your cloud name and API key in the Dashboard
-3. Make sure you're logged into Cloudinary in the same browser when using the CMS
 
 ## Usage
 
@@ -44,10 +36,17 @@ Visit `https://YOUR_DOMAIN/admin/` (note the trailing slash) and log in with Git
 ### Creating/Editing Posts
 
 - Posts are stored as Markdown files in the `blogs/` directory
-- Images are managed through Cloudinary's media library
+- Images are uploaded via Sveltia's built-in media library to `/img/uploads/`
 - Changes are committed directly to the `master` branch
 
-### Using Cloudinary Images in Templates
+### Draft Workflow
+
+- **New posts default to draft status** (`draft: true`)
+- Drafts show a "DRAFT:" prefix in the CMS post list
+- Uncheck the "Draft" checkbox to publish a post
+- Draft posts are automatically filtered from the live site
+
+### Using Images in Templates
 
 The `clImage` shortcode is available for responsive image rendering:
 
@@ -63,27 +62,30 @@ Or with custom widths and sizes:
 {% clImage imageUrl, "Alt text", [400, 800, 1200], "(min-width: 1024px) 800px, 100vw" %}
 ```
 
-Alternatively, you can use Cloudinary URLs directly in your templates:
-
-```njk
-<img src="{{ hero }}" alt="Hero image">
-```
-
 ## File Structure
 
-- `/admin/` - Decap CMS interface
+- `/admin/` - Sveltia CMS interface
 - `/api/` - Vercel serverless functions for GitHub OAuth
 - `/blogs/` - Blog post markdown files
+- `/img/uploads/` - Uploaded media files
 - `/_siteimg/` - Cached/optimized images (generated at build time)
+
+## Sveltia CMS Features
+
+- **Built-in asset management** with drag-and-drop uploads
+- **Image optimization** with WebP conversion
+- **Stock photo integration** (Pexels, Pixabay, Unsplash)
+- **Faster performance** using GitHub GraphQL API
+- **Keyboard shortcuts** (Ctrl/Cmd+S to save)
 
 ## Troubleshooting
 
 - If you can't log in, verify your GitHub OAuth app settings and Vercel environment variables
-- If the media library doesn't show, ensure you're logged into Cloudinary in the same browser
 - For trailing slash issues, the `vercel.json` configuration should handle this automatically
+- If assets don't upload, ensure the `img/uploads` folder exists in the repository
 
 ## Notes
 
-- The Cloudinary API key in `config.yml` is public; authentication happens via browser session
-- Images are optimized at build time using Eleventy Image plugin
 - The CMS commits directly to the `master` branch (simple publish mode)
+- Images are optimized at build time using Eleventy Image plugin
+- Existing posts without a `draft` field are treated as published

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -10,13 +10,6 @@ publish_mode: simple
 media_folder: "img/uploads"
 public_folder: "/img/uploads"
 
-# Use Cloudinary for media management
-media_library:
-  name: cloudinary
-  config:
-    cloud_name: dzdgmwhd6
-    api_key: 268617684873199
-
 collections:
   - name: "blog"
     label: "Blog"
@@ -24,21 +17,22 @@ collections:
     create: true
     slug: "{{slug}}"
     format: "frontmatter"
-    summary: "{{title}} — {{year}}-{{month}}-{{day}}"
+    summary: "{{draft | ternary('DRAFT: ','')}}{{title}} — {{year}}-{{month}}-{{day}}"
+    sortable_fields:
+      fields: [title, date, draft]
+      default:
+        field: date
+        direction: descending
     editor:
       preview: false
     fields:
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Date", name: "date", widget: "datetime" }
+      - { label: "Draft", name: "draft", widget: "boolean", default: true, hint: "Uncheck to publish" }
       - { label: "Description", name: "description", widget: "text", required: false }
       - { label: "Tags", name: "tags", widget: "list", required: false }
       - { label: "Layout", name: "layout", widget: "hidden", default: "layouts/post.njk" }
       - { label: "Emoji", name: "emoji", widget: "string", required: false, default: "📝" }
-      - label: "Hero Image"
-        name: "hero"
-        widget: "image"
-        required: false
-        media_library:
-          name: cloudinary
+      - { label: "Hero Image", name: "hero", widget: "image", required: false }
       - { label: "Social Image", name: "socialImage", widget: "image", required: false }
       - { label: "Body", name: "body", widget: "markdown" }

--- a/admin/index.html
+++ b/admin/index.html
@@ -6,15 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
   </head>
   <body>
-    <!-- Decap CMS container -->
-    <div id="nc-root"></div>
-    <!-- Load Decap CMS -->
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
-    <!-- Load Cloudinary media library -->
-    <script src="https://unpkg.com/decap-cms-media-library-cloudinary@^3.0.0/dist/index.js"></script>
-    <script>
-      // Register Cloudinary media library after CMS loads
-      CMS.registerMediaLibrary(cloudinary);
-    </script>
+    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
   </body>
 </html>

--- a/blog.njk
+++ b/blog.njk
@@ -4,4 +4,4 @@ templateClass: flow
 ---
 
 <h1>✍️ Blog</h1>
-{% set postslist = collections.blogs %} {% include "postgrid.njk" %}
+{% set postslist = collections.blogs | activePostsOnly %} {% include "postgrid.njk" %}

--- a/feed.njk
+++ b/feed.njk
@@ -21,7 +21,7 @@
   <link href="{{ permalink | url | absoluteUrl(metadata.url) }}" rel="self" />
   <link href="{{ metadata.url }}" />
   <updated
-    >{{ collections.posts | getNewestCollectionItemDate | dateToRfc3339
+    >{{ collections.posts | activePostsOnly | getNewestCollectionItemDate | dateToRfc3339
     }}</updated
   >
   <id>{{ metadata.url }}</id>
@@ -29,7 +29,7 @@
     <name>{{ metadata.author.name }}</name>
     <email>{{ metadata.author.email }}</email>
   </author>
-  {%- for post in collections.posts | reverse %} {%- if post.data.remoteURL %}
+  {%- for post in collections.posts | activePostsOnly | reverse %} {%- if post.data.remoteURL %}
   {%- set absolutePostUrl = post.data.remoteURL %} {%- else %} {%- set
   absolutePostUrl = post.url | absoluteUrl(metadata.url) %} {%- endif %}
   <entry>


### PR DESCRIPTION
## Summary
- Replace Decap CMS with Sveltia CMS (modern drop-in replacement)
- Remove Cloudinary media library, use Sveltia's built-in asset management
- Add draft/publish workflow with visual indicators in CMS
- Filter draft posts from blog listing and RSS feed

## Changes
- **admin/index.html**: Swap Decap CDN for Sveltia CMS
- **admin/config.yml**: Add draft field, remove Cloudinary config, add sortable fields
- **blog.njk & feed.njk**: Add `activePostsOnly` filter to exclude drafts
- **CMS_SETUP.md**: Updated documentation for Sveltia CMS

## Draft Workflow
- New posts default to `draft: true`
- CMS list shows "DRAFT:" prefix for unpublished posts
- Uncheck draft checkbox to publish
- Existing posts without draft field are treated as published

## Test plan
- [ ] Access `/admin/` and authenticate via GitHub
- [ ] Create a new draft post
- [ ] Verify draft shows "DRAFT:" prefix in CMS list
- [ ] Upload an image using built-in media library
- [ ] Uncheck draft and save - verify post appears on site
- [ ] Verify existing posts still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)