### PR TITLE
Add Sveltia CMS as alternative to Decap CMS

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,6 +29,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('js')
   eleventyConfig.addPassthroughCopy('play')
   eleventyConfig.addPassthroughCopy('admin')
+  eleventyConfig.addPassthroughCopy('admin-sveltia')
 
   eleventyConfig.addShortcode('year', () => `${new Date().getFullYear()}`)
 

--- a/admin-sveltia/config.yml
+++ b/admin-sveltia/config.yml
@@ -1,0 +1,47 @@
+backend:
+  name: github
+  repo: JoeHart/joe-simple-site
+  branch: master
+  base_url: https://www.joehart.co.uk
+  auth_endpoint: api/auth
+
+media_folder: "img/uploads"
+public_folder: "/img/uploads"
+
+media_library:
+  name: cloudinary
+  config:
+    cloud_name: dzdgmwhd6
+    api_key: 268617684873199
+
+collections:
+  - name: "blog"
+    label: "Blog"
+    folder: "blogs"
+    create: true
+    slug: "{{slug}}"
+    format: "frontmatter"
+    summary: "{{title}} — {{year}}-{{month}}-{{day}}"
+    editor:
+      preview: false
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Date", name: "date", widget: "datetime" }
+      - label: "Draft"
+        name: "draft"
+        widget: "boolean"
+        default: false
+        required: false
+        hint: "Set to true to hide this post from the live site"
+      - { label: "Description", name: "description", widget: "text", required: false }
+      - { label: "Tags", name: "tags", widget: "list", required: false }
+      - { label: "Layout", name: "layout", widget: "hidden", default: "layouts/post.njk" }
+      - { label: "Emoji", name: "emoji", widget: "string", required: false, default: "📝" }
+      - label: "Hero Image"
+        name: "hero"
+        widget: "image"
+        required: false
+        media_library:
+          name: cloudinary
+      - { label: "Social Image", name: "socialImage", widget: "image", required: false }
+      - { label: "Body", name: "body", widget: "markdown" }

--- a/admin-sveltia/index.html
+++ b/admin-sveltia/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Admin (Sveltia CMS)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link href="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
- Create /admin-sveltia/ with Sveltia CMS setup
- Add draft boolean field for publish status control
- Configure Cloudinary media library (native support)
- Add admin-sveltia to Eleventy passthrough copy

Sveltia CMS runs alongside existing Decap CMS at /admin/ for comparison and testing before full migration.