### PR TITLE
Add Linear MCP server configuration with token-based auth

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.linear.app/mcp",
+        "--header",
+        "Authorization: Bearer ${LINEAR_API_KEY}"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Configures the official Linear MCP server via mcp-remote, using the
LINEAR_API_KEY environment variable for Bearer token authentication.

https://claude.ai/code/session_01DNnaK7dLpyBvTvzTxrZivV