### PR TITLE
Move Final Fantasy IX talk to done

### DIFF
--- a/_data/upcomingTalks.json
+++ b/_data/upcomingTalks.json
@@ -1,11 +1,1 @@
-[
-  {
-    "title": "Final Fantasy IX in React",
-    "subtitle": "Fighting the Browser, One Frame at a Time",
-    "description": "The original Final Fantasy IX was a masterclass in creative constraint – pushing the PlayStation's hardware to its limits with tricks like pre-rendered backgrounds and low-res models. In this talk, Joe Hart recreates the magic in React, diving into WebGL, canvas positioning, and CSS hacks that should probably be illegal. It's part love letter to retro games, part deep dive into browser APIs, and part performance art.",
-    "conference": "React Advanced",
-    "location": "London",
-    "date": "2025-11-28",
-    "link": "https://reactadvanced.com/#person-joe-hart"
-  }
-]
+[]

--- a/index.njk
+++ b/index.njk
@@ -9,8 +9,7 @@ templateClass: homepage
 <div class="flow">
   <h3>Recent Posts</h3>
   {% set postslist = collections.posts | activePostsOnly | head(-5) %} {% set postslistCounter = collections.posts |
-  length %} {% include "postslist.njk" %}
-
+  length %} {% include "postslist.njk" %} {% if upcomingTalks.length %}
   <h3>Upcoming Talks</h3>
   <ol class="postlist">
     {% for talk in upcomingTalks %}
@@ -26,6 +25,7 @@ templateClass: homepage
     </li>
     {% endfor %}
   </ol>
+  {% endif %}
 
   <h3>Featured Talk</h3>
 

--- a/talks/final-fantasy-ix-in-react.md
+++ b/talks/final-fantasy-ix-in-react.md
@@ -1,0 +1,12 @@
+---
+title: 'Final Fantasy IX in React: Fighting the Browser, One Frame at a Time'
+description: The original Final Fantasy IX was a masterclass in creative constraint – pushing the PlayStation's hardware to its limits. In this talk, Joe recreates the magic in React.
+date: 2025-11-28
+tags: ['talk', 'react', 'games']
+layout: layouts/post.njk
+emoji: 📣
+---
+
+The original Final Fantasy IX was a masterclass in creative constraint – pushing the PlayStation's hardware to its limits with tricks like pre-rendered backgrounds and low-res models. In this talk, I recreate the magic in React, diving into WebGL, canvas positioning, and CSS hacks that should probably be illegal. It's part love letter to retro games, part deep dive into browser APIs, and part performance art.
+
+<a href="https://gitnation.com/contents/final-fantasy-ix-in-react-fighting-the-browser-one-frame-at-a-time">Watch it on the GitNation Website here</a>

--- a/talks/final-fantasy-ix-in-react.md
+++ b/talks/final-fantasy-ix-in-react.md
@@ -1,5 +1,5 @@
 ---
-title: 'Final Fantasy IX in React: Fighting the Browser, One Frame at a Time'
+title: 'Final Fantasy IX in React'
 description: The original Final Fantasy IX was a masterclass in creative constraint – pushing the PlayStation's hardware to its limits. In this talk, Joe recreates the magic in React.
 date: 2025-11-28
 tags: ['talk', 'react', 'games']

--- a/talks/final-fantasy-ix-in-react.md
+++ b/talks/final-fantasy-ix-in-react.md
@@ -7,6 +7,6 @@ layout: layouts/post.njk
 emoji: 📣
 ---
 
-The original Final Fantasy IX was a masterclass in creative constraint – pushing the PlayStation's hardware to its limits with tricks like pre-rendered backgrounds and low-res models. In this talk, I recreate the magic in React, diving into WebGL, canvas positioning, and CSS hacks that should probably be illegal. It's part love letter to retro games, part deep dive into browser APIs, and part performance art.
+This is a sort of sequel to the talk I did at Frontend North earlier in the year. Looking at trying to recreate the classic PS1 fantasy RPG in React. It looks at how to use React Three Fiber to render 3d scenes and how to get a logic loop working. A semi sequel to my Age of Empires 2 in React talk.
 
 <a href="https://gitnation.com/contents/final-fantasy-ix-in-react-fighting-the-browser-one-frame-at-a-time">Watch it on the GitNation Website here</a>


### PR DESCRIPTION
## Summary
- Moved the Final Fantasy IX in React talk (React Advanced, London, 2025-11-28) from upcoming to a published talk page
- Added talk page with description and link to the GitNation recording
- Cleared `_data/upcomingTalks.json` (now empty array)

## Test plan
- [ ] Verify the site builds successfully
- [ ] Check the talks page shows the new Final Fantasy IX talk
- [ ] Confirm the homepage no longer lists it as an upcoming talk
- [ ] Verify the talk page renders with the GitNation video link

🤖 Generated with [Claude Code](https://claude.com/claude-code)