### PR TITLE
Fix syndication push race condition

### DIFF
--- a/.github/workflows/syndicate-bluesky.yaml
+++ b/.github/workflows/syndicate-bluesky.yaml
@@ -36,4 +36,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/data/bluesky-posted.json notes/
-          git diff --staged --quiet || git commit -m "Update Bluesky posted tracker and backlinks" && git push
+          git diff --staged --quiet || git commit -m "Update Bluesky posted tracker and backlinks" && git pull --rebase && git push

--- a/.github/workflows/syndicate-mastodon.yaml
+++ b/.github/workflows/syndicate-mastodon.yaml
@@ -32,4 +32,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/data/mastodon-posted.json notes/
-          git diff --staged --quiet || git commit -m "Update Mastodon posted tracker and backlinks" && git push
+          git diff --staged --quiet || git commit -m "Update Mastodon posted tracker and backlinks" && git pull --rebase && git push


### PR DESCRIPTION
## Summary
- Both Bluesky and Mastodon syndication workflows trigger concurrently on the same event, so whichever pushes second gets rejected
- Added `git pull --rebase` before `git push` in both workflows so the second one rebases on top of the first's commit

## Test plan
- [ ] Push a new note and verify both syndication workflows succeed
- [ ] Check that both tracker files and backlinks are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)