### PR TITLE
Remove CSS view transitions

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -4,18 +4,10 @@ templateClass: post
 ---
 
 {% if hero %}
-<img
-  src="{{ hero }}"
-  alt="Hero image for {{ title }}"
-  class="post-hero"
-  style="view-transition-name: post-{{ page.fileSlug }}-hero"
-/>
+<img src="{{ hero }}" alt="Hero image for {{ title }}" class="post-hero" />
 {% endif %}
 
-<h1>
-  <span style="view-transition-name: post-{{ page.fileSlug }}-emoji" class="emoji">{{ emoji }}</span
-  ><span style="view-transition-name: post-{{ page.fileSlug }}-title">{{ title }}</span>
-</h1>
+<h1><span class="emoji">{{ emoji }}</span><span>{{ title }}</span></h1>
 <div class="post-metadata">
   <ul class="tags-list">
     {%- for tag in tags | filterTagList %} {%- set tagUrl %}/tags/{{ tag | slugify }}/{% endset %}
@@ -25,9 +17,7 @@ templateClass: post
     </li>
     {%- endfor %}
   </ul>
-  <time style="view-transition-name: post-{{ page.fileSlug }}-date" datetime="{{ page.date | htmlDateString }}">
-    {{ page.date | readableDate }}
-  </time>
+  <time datetime="{{ page.date | htmlDateString }}"> {{ page.date | readableDate }} </time>
 </div>
 
 <div class="flow">{{ content | safe }}</div>

--- a/_includes/postgrid.njk
+++ b/_includes/postgrid.njk
@@ -9,17 +9,14 @@
         alt="{{ post.data.title }}"
         width="1600"
         height="900"
-        style="view-transition-name: post-{{ post.fileSlug }}-hero"
       />
     </a>
     {% endif %}
 
     <h2 class="post-card-title">
-      <span style="view-transition-name: post-{{ post.fileSlug }}-emoji" class="post-card-emoji">
-        {{ post.data.emoji }}
-      </span>
+      <span class="post-card-emoji"> {{ post.data.emoji }} </span>
 
-      <a href="{{ link | url }}" style="view-transition-name: post-{{ post.fileSlug }}-title">
+      <a href="{{ link | url }}">
         {% if post.data.title %}{{ post.data.title }}{% else %}
         <code>{{ post.url }}</code>
         {% endif %}
@@ -35,13 +32,7 @@
         {% endfor %}
       </ul>
       {% endif %}
-      <time
-        class="post-card-date"
-        style="view-transition-name: post-{{ post.fileSlug }}-date"
-        datetime="{{ post.date | htmlDateString }}"
-      >
-        {{ post.date | readableDate }}
-      </time>
+      <time class="post-card-date" datetime="{{ post.date | htmlDateString }}"> {{ post.date | readableDate }} </time>
     </div>
 
     <p class="post-card-excerpt">

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,16 +1,13 @@
 <ol reversed class="postlist" style="counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}">
   {% for post in postslist | reverse %}
   <li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
-    <span style="view-transition-name: post-{{ post.fileSlug }}-emoji" class="postlist-emoji">{{post.data.emoji}}</span>
-    <a style="view-transition-name: post-{{ post.fileSlug }}-title" href="{{ post.url | url }}" class="postlist-link">
+    <span class="postlist-emoji">{{post.data.emoji}}</span>
+    <a href="{{ post.url | url }}" class="postlist-link">
       {% if post.data.title %}{{ post.data.title }} {% else %}
       <code>{{ post.url }}</code>
       {% endif %}
     </a>
-    <time
-      class="postlist-date no-wrap"
-      style="view-transition-name: post-{{ post.fileSlug }}-date"
-      datetime="{{ post.date | htmlDateString }}"
+    <time class="postlist-date no-wrap" datetime="{{ post.date | htmlDateString }}"
       >{{ post.date | readableDate }}</time
     >
   </li>

--- a/css/index.css
+++ b/css/index.css
@@ -1,6 +1,3 @@
-@view-transition {
-  navigation: auto;
-}
 :root {
   --contentwidth: 650px;
   /* @link https://utopia.fyi/type/calculator?c=320,18,1.2,1240,20,1.25,5,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12 */


### PR DESCRIPTION
## Summary
- Remove `@view-transition` at-rule from `css/index.css`
- Remove all `view-transition-name` inline styles from post templates (`post.njk`, `postslist.njk`, `postgrid.njk`)

## Test plan
- [x] Site builds successfully with `npm run build`
- [ ] Verify pages render correctly without view transition styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)