### PR TITLE
Add positioned image editor component to Sveltia CMS

### DIFF
--- a/admin-sveltia/editor-components.js
+++ b/admin-sveltia/editor-components.js
@@ -1,0 +1,50 @@
+CMS.registerEditorComponent({
+  id: 'positioned-image',
+  label: 'Positioned Image',
+  fields: [
+    { name: 'src', label: 'Image', widget: 'image' },
+    { name: 'alt', label: 'Alt Text', widget: 'string', default: '' },
+    {
+      name: 'position',
+      label: 'Position',
+      widget: 'select',
+      options: [
+        { label: 'Float Left', value: 'left' },
+        { label: 'Float Right', value: 'right' },
+        { label: 'Full Width', value: 'full' },
+      ],
+      default: 'left',
+    },
+  ],
+  pattern:
+    /^<img\s+(?:aria-hidden="true"\s+)?(?:class="(?<position_class>book-left|book-right)"\s+)?src="(?<src>[^"]+)"\s+alt="(?<alt>[^"]*)"\s*\/?>$/m,
+  fromBlock(match) {
+    const posClass = match.groups.position_class || ''
+    let position = 'full'
+    if (posClass === 'book-left') position = 'left'
+    if (posClass === 'book-right') position = 'right'
+    return {
+      src: match.groups.src || '',
+      alt: match.groups.alt || '',
+      position,
+    }
+  },
+  toBlock(data) {
+    const parts = ['<img aria-hidden="true"']
+    if (data.position === 'left') parts.push(' class="book-left"')
+    else if (data.position === 'right') parts.push(' class="book-right"')
+    parts.push(` src="${data.src || ''}"`)
+    parts.push(` alt="${data.alt || ''}"`)
+    parts.push('>')
+    return parts.join('')
+  },
+  toPreview(data) {
+    const style =
+      data.position === 'left'
+        ? 'float:left;width:30%;margin-right:1rem;'
+        : data.position === 'right'
+          ? 'float:right;width:30%;margin-left:1rem;'
+          : ''
+    return `<img src="${data.src || ''}" alt="${data.alt || ''}" style="${style}">`
+  },
+})

--- a/admin-sveltia/index.html
+++ b/admin-sveltia/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <title>Admin (Sveltia CMS)</title>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.css" rel="stylesheet" />
   </head>
   <body>
-    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
+    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
+    <script src="editor-components.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Register a `positioned-image` custom editor component in Sveltia CMS so authors can insert floating book cover images via the CMS UI instead of writing raw HTML
- Existing `<img>` tags with `book-left`/`book-right` classes are parsed and displayed as editable blocks
- Fix CMS script tag (`type="module"` removed) and remove redundant CSS link so `CMS.registerEditorComponent` works

## Test plan
- [ ] Open the CMS at `/admin-sveltia/`, edit a blog post
- [ ] Click the "+" button in the markdown toolbar — "Positioned Image" should appear
- [ ] Insert a new positioned image and verify the HTML output
- [ ] Open `books-i-read-2022` — existing `<img>` tags with `book-left`/`book-right` should render as editable Positioned Image blocks
- [ ] Run `npm run build` to confirm no breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)