### PR TITLE
Fix: Escape double quotes in positioned image alt text

### DIFF
--- a/admin-sveltia/editor-components.js
+++ b/admin-sveltia/editor-components.js
@@ -17,7 +17,7 @@ CMS.registerEditorComponent({
     },
   ],
   pattern:
-    /^<img\s+(?:aria-hidden="true"\s+)?(?:class="(?<position_class>book-left|book-right)"\s+)?src="(?<src>[^"]+)"\s+alt="(?<alt>[^"]*)"\s*\/?>$/m,
+    /^<img\s+(?:aria-hidden="true"\s+)?(?:class="(?<position_class>book-left|book-right)"\s+)?src="(?<src>[^"]+)"\s+alt="(?<alt>[^"]*(?:&quot;[^"]*?)*)"\s*\/?>$/m,
   fromBlock(match) {
     const posClass = match.groups.position_class || ''
     let position = 'full'
@@ -25,26 +25,28 @@ CMS.registerEditorComponent({
     if (posClass === 'book-right') position = 'right'
     return {
       src: match.groups.src || '',
-      alt: match.groups.alt || '',
+      alt: (match.groups.alt || '').replace(/&quot;/g, '"'),
       position,
     }
   },
   toBlock(data) {
+    const escAlt = (data.alt || '').replace(/"/g, '&quot;')
     const parts = ['<img aria-hidden="true"']
     if (data.position === 'left') parts.push(' class="book-left"')
     else if (data.position === 'right') parts.push(' class="book-right"')
     parts.push(` src="${data.src || ''}"`)
-    parts.push(` alt="${data.alt || ''}"`)
+    parts.push(` alt="${escAlt}"`)
     parts.push('>')
     return parts.join('')
   },
   toPreview(data) {
+    const escAlt = (data.alt || '').replace(/"/g, '&quot;')
     const style =
       data.position === 'left'
         ? 'float:left;width:30%;margin-right:1rem;'
         : data.position === 'right'
           ? 'float:right;width:30%;margin-left:1rem;'
           : ''
-    return `<img src="${data.src || ''}" alt="${data.alt || ''}" style="${style}">`
+    return `<img src="${data.src || ''}" alt="${escAlt}" style="${style}">`
   },
 })

--- a/blogs/book-thoughts-straight-acting-will-tosh.md
+++ b/blogs/book-thoughts-straight-acting-will-tosh.md
@@ -14,7 +14,7 @@ socialImage: ''
 
 Shakespeare being some shade of queer is an idea that you really only have two responses for. One being _“duh, of course”_ and the other being _“What? I’ve never heard about that?”_. Regardless of if you are the former or the later, this book is well worth a read.
 
-<img aria-hidden="true" class="book-right" src="/img/uploads/straight%20acting.jpg" alt="Cover of "Straight Acting by Will Tosh"">
+<img aria-hidden="true" class="book-right" src="/img/uploads/straight%20acting.jpg" alt="Cover of &quot;Straight Acting by Will Tosh&quot;">
 
 My partner bought this book from [Toppings Bookshop](https://www.toppingbooks.co.uk/) on a weekend away in Bath almost 2 years ago now. And it sat on his bedside table ever since, but at the beginning of the year we decided to listen to it in tandem. Both being absolute dweebs about the theatre and Shakespeare and of course being practicing homosexuals; the book seemed tailor made for us.
 


### PR DESCRIPTION
## Summary
- `toBlock` in the positioned image editor component was outputting unescaped `"` in the `alt` attribute, breaking the HTML tag and causing markdown-it to render it as visible text instead of an image
- `toBlock` and `toPreview` now escape `"` as `&quot;` in alt text
- `fromBlock` pattern and decoder updated to round-trip `&quot;` correctly
- Fixed the existing broken `<img>` tag in `book-thoughts-straight-acting-will-tosh.md`

## Test plan
- [ ] Verify https://www.joehart.co.uk/blogs/book-thoughts-straight-acting-will-tosh/ renders the book cover image correctly after deploy
- [ ] In the CMS, edit a positioned image with quotes in the alt text — confirm it saves and re-opens without corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)