### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -146,5 +146,6 @@
       </div>
     </footer>
     <script src="/js/burger-menu.js" type="module" defer></script>
+    <script defer src="/_vercel/insights/script.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
         "@openlab/vercel-netlify-cms-github": "^1.1.1",
+        "@vercel/analytics": "^1.6.1",
         "luxon": "^2.4.0",
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.6",
@@ -24,6 +25,9 @@
         "husky": "^9.1.7",
         "lint-staged": "^15.4.3",
         "prettier": "^3.5.1"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -951,6 +955,44 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "license": "MIT"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@11ty/eleventy-plugin-rss": "^1.2.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
     "@openlab/vercel-netlify-cms-github": "^1.1.1",
+    "@vercel/analytics": "^1.6.1",
     "luxon": "^2.4.0",
     "markdown-it": "^13.0.1",
     "markdown-it-anchor": "^8.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
+"@vercel/analytics@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz"
+  integrity sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==
+
 a-sync-waterfall@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz"


### PR DESCRIPTION
## Summary
- Adds the Vercel Web Analytics tracking script to the base layout
- Adds `@vercel/analytics` as a dependency

Resolves JOE-56

## Test plan
- [ ] Deploy preview and verify the analytics script loads at `/_vercel/insights/script.js`
- [ ] Check the Vercel Web Analytics dashboard for incoming page view data

🤖 Generated with [Claude Code](https://claude.com/claude-code)