### PR TITLE
Fix syndication trigger: use push to master instead of deleted workflow

### DIFF
--- a/.github/workflows/syndicate.yaml
+++ b/.github/workflows/syndicate.yaml
@@ -1,15 +1,15 @@
 name: Syndicate to Social
 
 on:
-  workflow_run:
-    workflows: ["Deploy Now: Orchestration"]
-    types: [completed]
+  push:
     branches: [master]
+    paths:
+      - 'notes/**'
+  workflow_dispatch:
 
 jobs:
   syndicate:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
         run: npm install --no-save @atproto/api
 
       - name: Wait for deployment propagation
-        run: sleep 60
+        run: sleep 30
 
       - name: Syndicate posts
         env:


### PR DESCRIPTION
The "Deploy Now: Orchestration" workflow was removed with IONOS, so the workflow_run trigger never fired. Switch to triggering on push to master with a path filter on notes/. Also add workflow_dispatch for manual runs and reduce the deploy wait from 60s to 30s for Vercel.

https://claude.ai/code/session_01URapWPqb926875n1z1nUoh