### PR TITLE
Fix deploy: URL-encode paths for Bunny Storage

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,13 +32,15 @@ jobs:
           find . -type f | while read file; do
             # Strip leading ./
             filepath="${file#./}"
+            # URL-encode the path (spaces and special chars)
+            encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$filepath")
             echo "Uploading: $filepath"
             curl --fail --silent --show-error \
               -X PUT \
               -H "AccessKey: $BUNNY_STORAGE_PASSWORD" \
               -H "Content-Type: application/octet-stream" \
               --data-binary "@$file" \
-              "https://${BUNNY_STORAGE_HOSTNAME}/${BUNNY_STORAGE_ZONE}/${filepath}"
+              "https://${BUNNY_STORAGE_HOSTNAME}/${BUNNY_STORAGE_ZONE}/${encoded}"
           done
 
       - name: Purge Bunny CDN cache


### PR DESCRIPTION
## Summary

- URL-encode file paths before uploading to Bunny Storage
- Fixes `curl: (3) URL rejected: Malformed input` caused by filenames with spaces (e.g. `straight acting.jpg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)