### PR TITLE
Use bunny-launcher for deploys and fix charset

### DIFF
--- a/.bunny/launcher.json
+++ b/.bunny/launcher.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/bunny-launcher/schema.json",
+  "build": {
+    "beforeDeploy": true,
+    "commands": ["npm ci", "npm run build"],
+    "outDir": "./_site",
+    "packageManager": "npm"
+  },
+  "domain": {
+    "name": "www.joehart.co.uk"
+  },
+  "notFound": {
+    "path": "/404.html",
+    "spa": false
+  }
+}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,39 +16,7 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build site
-        run: npm run build
-
-      - name: Upload to Bunny Storage
-        env:
-          BUNNY_STORAGE_ZONE: ${{ secrets.BUNNY_STORAGE_ZONE }}
-          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
-          BUNNY_STORAGE_HOSTNAME: ${{ secrets.BUNNY_STORAGE_HOSTNAME }}
-        run: |
-          cd _site
-          find . -type f | while read file; do
-            # Strip leading ./
-            filepath="${file#./}"
-            # URL-encode the path (spaces and special chars)
-            encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$filepath")
-            echo "Uploading: $filepath"
-            curl --fail --silent --show-error \
-              -X PUT \
-              -H "AccessKey: $BUNNY_STORAGE_PASSWORD" \
-              -H "Content-Type: application/octet-stream" \
-              --data-binary "@$file" \
-              "https://${BUNNY_STORAGE_HOSTNAME}/${BUNNY_STORAGE_ZONE}/${encoded}"
-          done
-
-      - name: Purge Bunny CDN cache
-        env:
-          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
-          BUNNY_PULL_ZONE_ID: ${{ secrets.BUNNY_PULL_ZONE_ID }}
-        run: |
-          curl --fail --silent --show-error \
-            -X POST \
-            -H "AccessKey: $BUNNY_API_KEY" \
-            "https://api.bunny.net/pullzone/${BUNNY_PULL_ZONE_ID}/purgeCache"
+      - name: Deploy to Bunny.net
+        uses: jlarmstrongiv/bunny-launcher-github-action@main
+        with:
+          accessKey: ${{ secrets.BUNNY_ACCESS_KEY }}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>{{ title or metadata.title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="{{ description or metadata.description }}" />


### PR DESCRIPTION
## Summary

- **Switch to [bunny-launcher](https://bunny-launcher.net/)** for deployments — handles incremental uploads, file cleanup, and CDN cache purging automatically
- **Add `<meta charset="utf-8">`** to fix emoji rendering — Bunny doesn't set charset in the Content-Type header like Vercel did

## Changes

- `.github/workflows/deploy.yaml` — replaced manual curl loop with `jlarmstrongiv/bunny-launcher-github-action`
- `.bunny/launcher.json` — config for build commands, output dir, domain, and 404 page
- `_includes/layouts/base.njk` — added charset meta tag

## Before merging

- [ ] Add `BUNNY_ACCESS_KEY` GitHub Secret (your Bunny account API key — may be the same as `BUNNY_API_KEY` you already set up)
- [ ] You may want to run `npx bunny-launcher --interactive` locally first to link the existing storage/pull zone to the config

## Test plan

- [ ] Verify deploy workflow succeeds
- [ ] Check emoji render correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)