### PR TITLE
Fix bunny-deploy: add required concurrency input

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,5 +31,6 @@ jobs:
           storage-endpoint: ${{ secrets.BUNNY_STORAGE_HOSTNAME }}
           access-key: ${{ secrets.BUNNY_API_KEY }}
           pull-zone-id: ${{ secrets.BUNNY_PULL_ZONE_ID }}
+          concurrency: "50"
           enable-delete-action: "true"
           enable-purge-pull-zone: "true"


### PR DESCRIPTION
## Summary

- Add `concurrency: "50"` — required in v3, set to Bunny's per-zone limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)