### PR TITLE
Remove skip-if-exists guard so social images always regenerate

### DIFF
--- a/_generate-social-image.js
+++ b/_generate-social-image.js
@@ -111,11 +111,6 @@ async function generateSocialImage(title, emoji, slug) {
   const outputFile = path.join(outputDir, `${slug}.png`)
   const publicPath = `/img/social/${slug}.png`
 
-  // Don't regenerate if already exists
-  if (fs.existsSync(outputFile)) {
-    return publicPath
-  }
-
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true })
   }


### PR DESCRIPTION
Previously, existing social images were never regenerated even after code improvements (like switching to Apple emoji PNGs). Now images are always regenerated during build to pick up rendering changes.

https://claude.ai/code/session_01QwqvTBGzZtPANMNE1vyTqV