### PR TITLE
Compress og:image / twitter:image meta tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -134,6 +134,33 @@ module.exports = function (eleventyConfig) {
       }
     })
 
+    // Rewrite og:image / twitter:image meta tags to a compressed JPEG variant.
+    // Social platforms reject images over ~600 KB; raw photos can be many megabytes.
+    const metaImageRegex = /<meta\b[^>]*\bproperty="(?:og:image|twitter:image)"[^>]*>/gi
+    result = result.replace(metaImageRegex, (tag) => {
+      const contentMatch = tag.match(/content="([^"]+)"/)
+      if (!contentMatch) return tag
+      const content = contentMatch[1]
+      const imgPathMatch = content.match(/\/img\/[^"]+/)
+      if (!imgPathMatch) return tag
+      const imgPath = imgPathMatch[0]
+      if (imgPath.startsWith('/img/social/')) return tag
+      if (!/\.(jpe?g|png)$/i.test(imgPath)) return tag
+      try {
+        const metadata = Image.statsSync(`.${imgPath}`, {
+          widths: [480, 800, 1280],
+          formats: ['webp', 'jpeg'],
+          urlPath: '/_siteimg/',
+          outputDir: './_site/_siteimg/',
+        })
+        const largestJpeg = metadata.jpeg[metadata.jpeg.length - 1]
+        const newContent = content.replace(imgPath, largestJpeg.url)
+        return tag.replace(/content="[^"]+"/, `content="${newContent}"`)
+      } catch (e) {
+        return tag
+      }
+    })
+
     return result
   })
 


### PR DESCRIPTION
## Summary
- Social validators (Facebook, X, LinkedIn, Discord, WhatsApp) reject OG images over ~600 KB. The Seattle bookshops post was serving its hero JPEG raw at **8.35 MB**.
- The existing `optimizeImages` HTML transform in `.eleventy.js` already resizes `<img>` tags and `<link rel="preload">` tags into optimized `/_siteimg/` variants — but it never touched `<meta property="og:image">` / `<meta property="twitter:image">`, so meta tags shipped the raw source.
- This change extends the transform with a new regex pass that rewrites those meta tags to the largest optimized JPEG variant (1280w, ~150–300 KB).

## Behaviour
- Skips `/img/social/*` so the auto-generated branded social cards (~30 KB) aren't reprocessed.
- Skips non-raster formats (`.gif`, `.svg`, `.ico`).
- Falls back silently if the variant can't be generated — same pattern as the existing preload rewriter.
- JPEG only (not WebP): broader compatibility with link previewers that don't render WebP reliably (Facebook, LinkedIn, older Slack, email clients).
- No frontmatter changes; explicit `socialImage` precedence is preserved.

## Test plan
- [ ] `yarn build` (or restart `yarn start`)
- [ ] `grep og:image _site/blogs/2026-05-12-seattle-in-five-bookshops/index.html` → URL ends with `/_siteimg/<hash>-1280.jpeg`, not `/img/lamplightbooks-sign.jpeg`
- [ ] `ls -lh _site/_siteimg/B95EyxCu_r-1280.jpeg` → under 600 KB (currently 170 KB)
- [ ] Deploy and check the post URL in https://www.opengraph.xyz/
- [ ] Spot-check a post with no `hero` (generated card path) — meta should still point at `/img/social/<slug>.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)