### PR TITLE
Add Atom feed link for blog posts

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -100,6 +100,7 @@
         person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
       })
     </script>
+    <link rel="alternate" type="application/atom+xml" title="Joe Hart — Blog" href="/feed.xml" />
     <link rel="alternate" type="application/atom+xml" title="Joe Hart's Notes (Atom)" href="/notes/feed.xml" />
     <link rel="alternate" type="application/feed+json" title="Joe Hart's Notes (JSON)" href="/notes/feed.json" />
     {% if hero or preloadImage %}


### PR DESCRIPTION
## Summary
Added an Atom feed link for the main blog to the base layout template, making the blog feed discoverable by feed readers and browsers.

## Changes
- Added `<link>` element for the blog's Atom feed (`/feed.xml`) in the document head
- The feed link is positioned before the existing Notes feed links for logical organization

## Details
This change enables feed reader discovery of the blog's Atom feed through standard feed autodiscovery mechanisms. The feed link follows the same pattern as the existing Notes feeds already present in the layout.

https://claude.ai/code/session_01Wyd1adt32UWAVduVxEsh1b